### PR TITLE
raftstore:  bug fix on failing to restart after tikv OOM crash

### DIFF
--- a/components/engine_rocks/src/options.rs
+++ b/components/engine_rocks/src/options.rs
@@ -17,7 +17,7 @@ impl From<engine_traits::ReadOptions> for RocksReadOptions {
     fn from(opts: engine_traits::ReadOptions) -> Self {
         let mut r = RawReadOptions::default();
         r.fill_cache(opts.fill_cache());
-        r.set_read_tier(opts.read_tier());
+        r.set_read_tier(opts.read_tier() as i32);
         RocksReadOptions(r)
     }
 }

--- a/components/engine_rocks/src/options.rs
+++ b/components/engine_rocks/src/options.rs
@@ -17,6 +17,7 @@ impl From<engine_traits::ReadOptions> for RocksReadOptions {
     fn from(opts: engine_traits::ReadOptions) -> Self {
         let mut r = RawReadOptions::default();
         r.fill_cache(opts.fill_cache());
+        r.set_read_tier(opts.read_tier());
         RocksReadOptions(r)
     }
 }

--- a/components/engine_traits/src/options.rs
+++ b/components/engine_traits/src/options.rs
@@ -2,10 +2,17 @@
 use std::ops::Bound;
 use tikv_util::keybuilder::KeyBuilder;
 
+#[repr(i32)]
+#[derive(Clone)]
+pub enum ReadTie {
+    All = 0,
+    Sst = 2,
+}
+
 #[derive(Clone)]
 pub struct ReadOptions {
     fill_cache: bool,
-    read_tier: i32,
+    read_tier: ReadTie,
 }
 
 impl ReadOptions {
@@ -24,12 +31,12 @@ impl ReadOptions {
     }
 
     #[inline]
-    pub fn read_tier(&self) -> i32 {
-        self.read_tier
+    pub fn read_tier(&self) -> ReadTie {
+        self.read_tier.clone()
     }
 
     #[inline]
-    pub fn set_read_tier(&mut self, v: i32) {
+    pub fn set_read_tier(&mut self, v: ReadTie) {
         self.read_tier = v;
     }
 }
@@ -38,7 +45,7 @@ impl Default for ReadOptions {
     fn default() -> ReadOptions {
         ReadOptions {
             fill_cache: true,
-            read_tier: 0, // all tier
+            read_tier: ReadTie::All, // all tier
         }
     }
 }

--- a/components/engine_traits/src/options.rs
+++ b/components/engine_traits/src/options.rs
@@ -5,6 +5,7 @@ use tikv_util::keybuilder::KeyBuilder;
 #[derive(Clone)]
 pub struct ReadOptions {
     fill_cache: bool,
+    read_tier: i32,
 }
 
 impl ReadOptions {
@@ -21,11 +22,24 @@ impl ReadOptions {
     pub fn set_fill_cache(&mut self, v: bool) {
         self.fill_cache = v;
     }
+
+    #[inline]
+    pub fn read_tier(&self) -> i32 {
+        self.read_tier
+    }
+
+    #[inline]
+    pub fn set_read_tier(&mut self, v: i32) {
+        self.read_tier = v;
+    }
 }
 
 impl Default for ReadOptions {
     fn default() -> ReadOptions {
-        ReadOptions { fill_cache: true }
+        ReadOptions {
+            fill_cache: true,
+            read_tier: 0, // all tier
+        }
     }
 }
 

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -2389,13 +2389,17 @@ where
                 .tablet_factory
                 .tablet_path(new_region.get_id(), RAFT_INIT_LOG_INDEX);
             to_cloned.push(tablet_path);
+            let mut output_stream = CodedOutputStream::vec(&mut apply_result);
             new_region
-                .write_length_delimited_to(&mut CodedOutputStream::vec(&mut apply_result))
+                .write_length_delimited_to(&mut output_stream)
                 .unwrap();
+            output_stream.flush().unwrap();
         }
+        let mut output_stream = CodedOutputStream::vec(&mut apply_result);
         derived
-            .write_length_delimited_to(&mut CodedOutputStream::vec(&mut apply_result))
+            .write_length_delimited_to(&mut output_stream)
             .unwrap();
+        output_stream.flush().unwrap(); 
         let apply_res_key = keys::region_apply_result_key(derived.get_id(), cur_index);
         write_peer_state(kv_wb_mut, &derived, PeerState::Normal, None, cur_index, 0)
             .and_then(|_| {

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -11,8 +11,8 @@ use batch_system::{BasicMailbox, Fsm};
 use collections::HashMap;
 use engine_traits::CF_RAFT;
 use engine_traits::{
-    Engines, KvEngine, RaftEngine, RaftLogBatch, SSTMetaInfo, WriteBatch, WriteBatchExt,
-    WriteOptions,
+    Engines, KvEngine, RaftEngine, RaftLogBatch, ReadOptions, SSTMetaInfo, WriteBatch,
+    WriteBatchExt, WriteOptions,
 };
 use error_code::ErrorCodeExt;
 use fail::fail_point;
@@ -132,6 +132,9 @@ where
     max_inflight_msgs: usize,
 
     trace: PeerMemoryTrace,
+
+    // read applied idx from sst for GC
+    check_trancated_idx_for_gc: bool,
 }
 
 pub struct BatchRaftCmdRequestBuilder<E>
@@ -232,6 +235,7 @@ where
                 ),
                 max_inflight_msgs: cfg.raft_max_inflight_msgs,
                 trace: PeerMemoryTrace::default(),
+                check_trancated_idx_for_gc: cfg.disable_tablet_wal,
             }),
         ))
     }
@@ -277,6 +281,7 @@ where
                 ),
                 max_inflight_msgs: cfg.raft_max_inflight_msgs,
                 trace: PeerMemoryTrace::default(),
+                check_trancated_idx_for_gc: cfg.disable_tablet_wal,
             }),
         ))
     }
@@ -2211,18 +2216,59 @@ where
         }
     }
 
+    fn get_flushed_trancated_idx(&mut self, region_id: u64) -> u64 {
+        let state_key = keys::apply_state_key(region_id);
+        let mut opts = ReadOptions::new();
+        const PERSISTED_TIER: i32 = 0x2;
+        opts.set_read_tier(PERSISTED_TIER);
+        let mut m = RaftApplyState::default();
+        if let Some(tablet) = self.fsm.peer.get_store().tablet() {
+            let value = tablet.get_value_cf_opt(&opts, CF_RAFT, &state_key).unwrap();
+            if !value.is_none() {
+                m.merge_from_bytes(&value.unwrap()).unwrap();
+                return cmp::min(m.get_truncated_state().get_index(), m.applied_index);
+            }
+        }
+
+        let value = self
+            .ctx
+            .engines
+            .kv
+            .get_value_cf_opt(&opts, CF_RAFT, &state_key)
+            .unwrap();
+        if value.is_none() {
+            return 0;
+        }
+        m.merge_from_bytes(&value.unwrap()).unwrap();
+        cmp::min(m.get_truncated_state().get_index(), m.applied_index)
+    }
+
     fn on_ready_compact_log(&mut self, first_index: u64, state: RaftTruncatedState) {
         let total_cnt = self.fsm.peer.last_applying_idx - first_index;
+
+        let mut index = state.get_index();
+        if self.fsm.check_trancated_idx_for_gc {
+            let last_trancated_idx =
+                self.get_flushed_trancated_idx(self.fsm.peer.get_store().get_region_id());
+            if last_trancated_idx != 0 && last_trancated_idx - 1 < index {
+                debug!("on_ready_compact_log update index.";
+                    "region" => self.fsm.peer.get_store().get_region_id(),
+                    "original" => index,
+                    "new value" => last_trancated_idx-1);
+                index = last_trancated_idx - 1;
+            }
+        }
         // the size of current CompactLog command can be ignored.
-        let remain_cnt = self.fsm.peer.last_applying_idx - state.get_index() - 1;
+        let remain_cnt = self.fsm.peer.last_applying_idx - index - 1;
         self.fsm.peer.raft_log_size_hint =
             self.fsm.peer.raft_log_size_hint * remain_cnt / total_cnt;
-        let compact_to = state.get_index() + 1;
+        let compact_to = index + 1;
         let task = RaftlogGcTask::gc(
             self.fsm.peer.get_store().get_region_id(),
             self.fsm.peer.last_compacted_idx,
             compact_to,
         );
+        let start_idx = self.fsm.peer.last_compacted_idx;
         self.fsm.peer.last_compacted_idx = compact_to;
         self.fsm.peer.mut_store().compact_to(compact_to);
         if let Err(e) = self.ctx.raftlog_gc_scheduler.schedule(task) {
@@ -2231,6 +2277,14 @@ where
                 "region_id" => self.fsm.region_id(),
                 "peer_id" => self.fsm.peer_id(),
                 "err" => %e,
+            );
+        } else {
+            debug!(
+                "successfully to schedule compact task";
+                "region_id" => self.fsm.region_id(),
+                "peer_id" => self.fsm.peer_id(),
+                "start_idx" => start_idx,
+                "end_idx" => compact_to,
             );
         }
     }

--- a/components/raftstore/src/store/worker/raftlog_gc.rs
+++ b/components/raftstore/src/store/worker/raftlog_gc.rs
@@ -113,7 +113,7 @@ impl<EK: KvEngine, ER: RaftEngine, R: CasualRouter<EK>> Runner<EK, ER, R> {
                             self.report_collected(0);
                         }
                         Ok(n) => {
-                            debug!("gc log entries"; "region_id" => region_id, "entry_count" => n);
+                            debug!("gc log entries"; "region_id" => region_id, "entry_count" => n, "start_idx" => start_idx, "end_idx" => end_idx);
                             self.report_collected(n);
                         }
                     }


### PR DESCRIPTION
Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
Tikv failed to start after OOM crash. A few symptons:
1) fail to read the apply result from tablet after restart.
2) failed to find the record of last applied index.
3) failed to find the record of last truncated index

What's Changed:
1) In apply.rs exec_batch_split, Flush the stream before write the apply_result to rocksdb.
2) When GC, read the last applied index from SST directly.
3) When initializing , reading the apply state from kv instead of tablet if it just applied the snapshot. 

Tests
- Integration test

Side effects
None
